### PR TITLE
implement @timer

### DIFF
--- a/statman/__init__.py
+++ b/statman/__init__.py
@@ -4,5 +4,6 @@ from .gauge import Gauge
 from .history import History
 from .calculation import Calculation
 from .metric import Metric
+from .decorators import timer
 
 __all__ = ['Statman', 'Stopwatch']

--- a/statman/decorators.py
+++ b/statman/decorators.py
@@ -1,0 +1,17 @@
+from .statman import Statman
+
+
+def timer(name):
+
+    def timer_inner_decorator(func):
+
+        def timer_wrapper(*args, **kwargs):
+            sw = Statman.stopwatch(name=name, enable_history=True)
+            sw.start()
+            result = func(*args, **kwargs)
+            sw.stop()
+            return result
+
+        return timer_wrapper
+
+    return timer_inner_decorator

--- a/statman/tests/test_timer_decorator.py
+++ b/statman/tests/test_timer_decorator.py
@@ -1,0 +1,34 @@
+import unittest
+import time
+import statman
+from statman import Statman
+from statman.stopwatch import Stopwatch
+
+
+class TestStopwatch(unittest.TestCase):
+
+    def test_decorator_stopwatch(self):
+        delay = 7
+        result = self.sut('moto', delay=delay)
+        self.assertEqual(result, 'hello moto')
+
+        self.assertIsNotNone(Statman.stopwatch('sut.timer'))
+        self.assertEqual(Statman.stopwatch('sut.timer').name, 'sut.timer')
+        self.assertAlmostEqual(Statman.stopwatch('sut.timer').value, delay, delta=0.1)
+
+    @statman.timer(name="sut.timer")
+    def sut(self, n: str, delay: int = 1):
+        msg = f'hello {n}'
+        print(msg)
+        time.sleep(delay)
+        return msg
+
+    def test_decorator_stopwatch_2(self):
+        delay = 5
+        result = self.sut('moto2', delay=delay)
+        self.assertEqual(result, 'hello moto2')
+        # self.assertAlmostEqual(stopwatch.read(), test_time_s, delta=self._accepted_variance)
+
+        self.assertIsNotNone(Statman.stopwatch('sut.timer'))
+        self.assertEqual(Statman.stopwatch('sut.timer').name, 'sut.timer')
+        self.assertAlmostEqual(Statman.stopwatch('sut.timer').value, delay, delta=0.1)


### PR DESCRIPTION
Complete:
(1) timer

Need to add:
(2) documentation
(3) thread safety
(4) then release

Maybe.. SM.stopwatch can ONLY be used to get an instance, and that metric spot ONLY holds history.
Or maybe that is only if you enable thread safety.
